### PR TITLE
Refactor the library to bring it up-to-date

### DIFF
--- a/lib/pry-sorbet.rb
+++ b/lib/pry-sorbet.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'pry'
+require 'pry-sorbet/version'
+
+require 'pry-sorbet/extensions.rb'

--- a/lib/pry-sorbet/extensions.rb
+++ b/lib/pry-sorbet/extensions.rb
@@ -32,8 +32,6 @@ class Pry
         call_chain = []
 
         # Modifiers
-        call_chain << "generated" if signature.generated
-
         if signature.mode != "standard"
           # This is a string like "overridable_override"
           call_chain += signature.mode.split("_")

--- a/lib/pry-sorbet/extensions.rb
+++ b/lib/pry-sorbet/extensions.rb
@@ -1,5 +1,4 @@
-require 'sorbet-runtime'
-require 'pry'
+# frozen_string_literal: true
 
 class Pry
   class Command
@@ -7,7 +6,7 @@ class Pry
       old_method_sections = instance_method(:method_sections)
 
       define_method(:method_sections) do |code_object|
-        sorbet_object = T::Private::Methods.signature_for_method(code_object)
+        sorbet_object = defined?(T::Private::Methods) && T::Private::Methods.signature_for_method(code_object)
 
         if sorbet_object
           call_chain = []

--- a/lib/pry-sorbet/extensions.rb
+++ b/lib/pry-sorbet/extensions.rb
@@ -46,7 +46,7 @@ class Pry
           #   Block
           if sorbet_object.block_type
             all_parameters << "#{sorbet_object.block_name}: #{sorbet_object.block_type}"
-          end          
+          end
 
           call_chain << "params(#{all_parameters.join(", ")})" if all_parameters.any?
 

--- a/lib/pry-sorbet/version.rb
+++ b/lib/pry-sorbet/version.rb
@@ -1,4 +1,4 @@
-require_relative 'extension.rb'
+# frozen_string_literal: true
 
 module PrySorbet
   VERSION = '0.1.0'

--- a/pry-sorbet.gemspec
+++ b/pry-sorbet.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "pry"
+
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/pry-sorbet.gemspec
+++ b/pry-sorbet.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "sorbet-runtime"
 end


### PR DESCRIPTION
This PR introduces some cosmetic refactors, like extracting methods to make code more readable, and some structural refactors, like improving the `Method#source_location` performance and restructuring the file/folder hierarchy.

Each change is done atomically in a separate commit, so best to view the PR commit-by-commit.