### PR TITLE
Add `sorbet-unwrap` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,35 +3,6 @@
 pry-sorbet is a Pry extension which enables it to work seamlessly with Sorbet
 projects.
 
-**Before:** Incorrect method source
-
-```
-From: /home/aaron/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/sorbet-runtime-0.4.4929/lib/types/private/methods/_methods.rb @ line 208:
-Owner: #<Class:Foo>
-Visibility: public
-Number of lines: 35
-
-T::Private::ClassUtils.replace_method(mod, method_name) do |*args, &blk|
-  if !T::Private::Methods.has_sig_block_for_method(new_method)
-    # This should only happen if the user used alias_method to grab a handle
-    # to the original pre-unwound `sig` method. I guess we'll just proxy the
-    # call forever since we don't know who is holding onto this handle to
-```
-
-**After:** Method source and a signature!
-
-```
-From: playground/test.rb @ line 9:
-Owner: #<Class:Foo>
-Visibility: public
-Sorbet: sig { returns(Integer) }
-Number of lines: 3
-
-def self.bar
-  3
-end
-```
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -50,8 +21,135 @@ Or install it yourself as:
 
 ## Usage
 
-Make sure you've required `pry-sorbet`. The `$` command in Pry will be
-automatically overwritten to add the Sorbet-specific functionality.
+### Fixes method source
+
+Since Sorbet runtime wraps methods with a signature to execute runtime checks
+on parameters and return values, the source location of methods end up pointing
+to a file location in the `sorbet-runtime` gem.
+
+`pry-sorbet` automatically fixes the information returned by the `show-source`
+(also known as `$`) command to list the correct method source location.
+
+Moreover, an extra entry is added to the header of the method listing, named
+`Sorbet`, which displays the method signature if it exists.
+
+**Before:** Incorrect method source, no method signature
+
+```
+From: /Users/user/.gem/ruby/2.6.5/gems/sorbet-runtime-0.5.5427/lib/types/private/methods/_methods.rb @ line 208:
+Owner: Foo
+Visibility: public
+Number of lines: 35
+
+T::Private::ClassUtils.replace_method(mod, method_name) do |*args, &blk|
+  if !T::Private::Methods.has_sig_block_for_method(new_method)
+    # This should only happen if the user used alias_method to grab a handle
+    # to the original pre-unwound `sig` method. I guess we'll just proxy the
+    # call forever since we don't know who is holding onto this handle to
+    # replace it.
+```
+
+**After:** Method source and a signature!
+
+```
+From: test/test.rb @ line 8:
+Owner: Foo
+Visibility: public
+Sorbet: sig { params(bar: Symbol, baz: Integer).returns(String) }
+Number of lines: 3
+
+def foo(bar, baz)
+  [baz.to_s, bar.to_s].join(":")
+end
+```
+
+### Helps with debugging
+
+Because of the same method wrapping, debugging source code that has Sorbet signatures
+becomes really painful. When stepping through the code, one always hits code locations
+that are in the `sorbet-runtime` library and most of the time it makes people end up
+missing the actual method invocation.
+
+`pry-sorbet` adds a Sorbet specific command, `sorbet-unwrap` that can be ran to unwrap
+all Sorbet wrapped methods. This allows developers to easily step through their code
+without having to deal with the `sorbet-runtime` library.
+
+**Before**
+
+```
+$ ruby -I lib -r pry-sorbet test/test.rb
+
+From: test/test.rb @ line 14 :
+
+     4: class Foo
+     5:   extend T::Sig
+     6:
+     7:   sig { params(bar: Symbol, baz: Integer).returns(String) }
+     8:   def foo(bar, baz)
+     9:     [baz.to_s, bar.to_s].join(":")
+    10:   end
+    11: end
+    12:
+    13: binding.pry
+ => 14: puts Foo.new.foo(:bar, 1)
+
+[1] pry(main)> step
+
+From: /Users/user/.gem/ruby/2.6.5/gems/sorbet-runtime-0.5.5427/lib/types/private/methods/_methods.rb @ line 209 Foo#foo:
+
+    204:     # which is called only on the *first* invocation.
+    205:     # This wrapper is very slow, so it will subsequently re-wrap with a much faster wrapper
+    206:     # (or unwrap back to the original method).
+    207:     new_method = nil
+    208:     T::Private::ClassUtils.replace_method(mod, method_name) do |*args, &blk|
+ => 209:       if !T::Private::Methods.has_sig_block_for_method(new_method)
+    210:         # This should only happen if the user used alias_method to grab a handle
+    211:         # to the original pre-unwound `sig` method. I guess we'll just proxy the
+    212:         # call forever since we don't know who is holding onto this handle to
+    213:         # replace it.
+    214:         new_new_method = mod.instance_method(method_name)
+```
+
+**After**
+
+```
+$ ruby -I lib -r pry-sorbet test/test.rb
+
+From: test/test.rb @ line 14 :
+
+     4: class Foo
+     5:   extend T::Sig
+     6:
+     7:   sig { params(bar: Symbol, baz: Integer).returns(String) }
+     8:   def foo(bar, baz)
+     9:     [baz.to_s, bar.to_s].join(":")
+    10:   end
+    11: end
+    12:
+    13: binding.pry
+ => 14: puts Foo.new.foo(:bar, 1)
+
+[1] pry(main)> sorbet-unwrap
+[2] pry(main)> step
+
+From: test/test.rb @ line 9 Foo#foo:
+
+     8: def foo(bar, baz)
+ =>  9:   [baz.to_s, bar.to_s].join(":")
+    10: end
+```
+
+Method unwrapping is not done automatically, you still need to call the `sorbet-unwrap`
+command before stepping through code. However, you can make this automatic by adding the
+following snippet to your  `~/.pryrc` file:
+
+```ruby
+if defined?(PrySorbet)
+  Pry.hooks.add_hook(:before_session, "sorbet-unwrap") do |output, binding, pry|
+    pry.run_command "sorbet-unwrap"
+  end
+end
+```
 
 ## Contributing
 

--- a/lib/pry-sorbet.rb
+++ b/lib/pry-sorbet.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require 'pry'
-require 'pry-sorbet/version'
 
+module PrySorbet
+end
+
+require 'pry-sorbet/version'
 require 'pry-sorbet/extensions.rb'
+require 'pry-sorbet/commands.rb'

--- a/lib/pry-sorbet/commands.rb
+++ b/lib/pry-sorbet/commands.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "pry-sorbet/commands/unwrap_command"

--- a/lib/pry-sorbet/commands/unwrap_command.rb
+++ b/lib/pry-sorbet/commands/unwrap_command.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module PrySorbet
+  class UnwrapCommand < Pry::ClassCommand
+    match "sorbet-unwrap"
+    group "Sorbet"
+    description "Unwrap all methods wrapped by Sorbet runtime"
+    command_options requires_gem: "sorbet-runtime"
+
+    banner <<~BANNER
+      Usage: sorbet-unwrap
+
+      Unwrap all methods wrapped by Sorbet runtime
+    BANNER
+
+    def process
+      return unless defined?(T::Private::Methods)
+
+      # For each signature wrapper, call the lambda associated with the wrapper
+      # to finalize the method wrapping
+      sig_wrappers = T::Private::Methods.instance_variable_get(:@sig_wrappers) || {}
+      sig_wrappers.values.each do |sig_wrapper|
+        sig_wrapper.call
+      rescue NameError
+      end
+
+      # Now that all methods are properly wrapped with optimized wrappers
+      # we can replace them with the original methods
+      signatures_by_method = T::Private::Methods.instance_variable_get(:@signatures_by_method) || {}
+      signatures_by_method.values.each do |signature|
+        T::Configuration.without_ruby_warnings do
+          T::Private::DeclState.current.without_on_method_added do
+            signature.owner.send(:define_method, signature.method_name, signature.method)
+          end
+        end
+      end
+    end
+  end
+end
+
+Pry::Commands.add_command(PrySorbet::UnwrapCommand)


### PR DESCRIPTION
Debugging code with Sorbet signatures is really hard due to Sorbet method wrapping. When stepping through code, one always hits `sorbet-runtime` locations, which is distracting and confusing.

This PR adds a `sorbet-unwrap` command to remove all Sorbet method wrappers from methods. This is again done by reaching into `sorbet-runtime` private classes and instance variables, but the internals of this part of the `sorbet-runtime` codebase seems to be fairly stable.

The `README` is updated with more explanation of what the gem does and how it works.